### PR TITLE
ci(env): setting github.event.number to nxbranch

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     env:
-      NX_BRANCH: ${{ github.ref }}
+      NX_BRANCH: ${{ github.event.number }}
       NX_RUN_GROUP: ${{ github.action }}
     runs-on: ${{ matrix.operating-system }}
     strategy:


### PR DESCRIPTION
Setting the `{{ github.event.number }}` value to `NX_BRANCH` environment variables so nxCloud can gather information about the runs.